### PR TITLE
ignore ruby bundler files, add a members folder so building works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,10 @@ ENV/
 _site/
 .sass-cache/
 .jekyll-metadata
+
+# Members files
+static/images/members/*
+
+# Bundle
+.bundle
+vendor

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,7 +49,7 @@ DEPENDENCIES
   minima (~> 2.0)
 
 RUBY VERSION
-   ruby 2.3.1p112
+   ruby 2.4.0p0
 
 BUNDLED WITH
    1.14.3

--- a/README.md
+++ b/README.md
@@ -2,10 +2,20 @@
 Stateless, Dateless, Flawless
 
 ## Configure Jekyll
-`sudo gem install ruby`
-`sudo gem isntall bundler`
-`bundle install`
-`jekyll serve`
+
+```BASH
+gem --version || sudo gem install ruby
+bundle --version || sudo gem isntall bundler
+bundle install
+jekyll serve
+```
+
+or if you don't want to install these deps globally:
+
+```BASH
+bundle install --path vendor/bundle
+bundle exec jekyll serve
+```
 
 ## Instructions for Updating Website
 

--- a/_config.yml
+++ b/_config.yml
@@ -32,6 +32,8 @@ exclude:
   - Gemfile
   - Gemfile.lock
   - README.md
+  - .bundle
+  - vendor
 collections:
   - homepage
   - events


### PR DESCRIPTION
Fixes the issue we had during the meeting, also adds the `members` folder in `static/images` since that folder needs to exist when the plugin is run.
Fixes #4 