### PR TITLE
removed unecessary info disclosure

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-hackgt-org-website.dev.hack.gt

--- a/_config.yml
+++ b/_config.yml
@@ -22,6 +22,10 @@ exclude:
   - Dockerfile
   - .dockerignore
   - .gitignore
+  - docker_resources
+  - deployment.yaml
+  - precheck.rb
+  - LICENSE
 
 collections:
   - homepage


### PR DESCRIPTION
Some things that probably shouldn't be things:
```
https://org-site.dev.hack.gt/docker_resources/build.sh
https://org-site.dev.hack.gt/LICENSE
https://org-site.dev.hack.gt/deployment.yaml
https://org-site.dev.hack.gt/precheck.rb
```

Just removed them from site generation.