### PR TITLE
Quick fixes

### DIFF
--- a/_frontpage_blurbs/community.md
+++ b/_frontpage_blurbs/community.md
@@ -1,7 +1,8 @@
 ---
 title: HackGT is about
 kahuna: " Community"
-linkto: team
+image: team
+linkto: events
 linkmessage: Learn more about our events
 ---
 

--- a/_frontpage_blurbs/meet-the-team.md
+++ b/_frontpage_blurbs/meet-the-team.md
@@ -1,7 +1,8 @@
 ---
 title: Meet the HackG
 kahuna: "Team"
-linkto: karaoke
+image: karaoke
+linkto: about
 linkmessage: Check out our team
 ---
 HackGT is team of undergraduate students at Georgia Tech that encourage members of its team to make an impact around them - whether that is through solving problems hackathon organizers face or improving the outlook of our events with polish and professionalism.

--- a/_pages/code.html
+++ b/_pages/code.html
@@ -1,7 +1,7 @@
 ---
 layout: main
 title: Code
-slogan: At HackGT, we build the technology behind hackathons. We believe in making our solutions available through open source projects on <a href="https://github.com/HackGT" target="_blank">Github</a>.
+slogan: At HackGT, we build the technology behind hackathons. We believe in making our solutions available through open source projects on <a href="https://github.com/HackGT" target="_blank">GitHub</a>.
 theme: light
 id: code
 permalink: /code/

--- a/_pages/events.html
+++ b/_pages/events.html
@@ -77,9 +77,9 @@ footer-js:
                 {% assign csv_name = current_year | append: '-exec' %}
                 {% if site.data[csv_name] %}
                     <h3 class="board">Exec board</h3>
-                    <div class="row">
+                    <div class="row exec-row">
                     {% for exec in site.data[csv_name] %}
-                        <div class="col-2 exec-member">
+                        <div class="exec-member">
                             <img class="exec-member-img" src="{{ exec.image }}"/>
                             <p>{{ exec.name}} <br/> {{ exec.title }}</p>
                         </div>

--- a/_pages/events.html
+++ b/_pages/events.html
@@ -2,7 +2,7 @@
 layout: main
 title: Events
 permalink: /events/
-theme: light
+theme: dark
 id: events
 js:
     - animatedScrollTo

--- a/_pages/home.html
+++ b/_pages/home.html
@@ -7,11 +7,10 @@ js:
     - snap-min
 footer-js:
     - home
-main-event: 5.hack.gt
 ---
             <div id="slogan">
                 <h3>Organize. Serve. <br/> Make an Impact. Repeat.</h3>
-                <h3><a class="gradient-text gradient-underline border-jump" href="https://{{ page.main-event }}/">Attend!</a></h3>
+                <h3><a class="gradient-text gradient-underline border-jump" href="{% if page.main-event %} https://{{ page.main-event }}/ {% else %} /events {%endif%}">Attend!</a></h3>
                 <p><span class="chevron"></span></p>
             </div>
            {% if site.upcoming_events.size > 0 %}

--- a/_pages/home.html
+++ b/_pages/home.html
@@ -43,7 +43,7 @@ main-event: 5.hack.gt
             {% for blurb in site.frontpage_blurbs %}
             <div class="article row">
                 <div class="col-7 article-img">
-                    <img src="/assets/frontpage/{{ blurb.linkto}}.jpg"/>
+                    <img src="/assets/frontpage/{{ blurb.image}}.jpg"/>
                 </div>
 
                 <div class="col-5 full-col">

--- a/assets/timeline-glyph.svg
+++ b/assets/timeline-glyph.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="140px" height="160px" viewBox="0 0 140 160" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 47.1 (45422) - http://www.bohemiancoding.com/sketch -->
+    <title>Group</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <linearGradient x1="0%" y1="0%" x2="100%" y2="100%" id="linearGradient-1">
+            <stop stop-color="#4AC8EF" offset="0%"></stop>
+            <stop stop-color="#8B54A2" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Group" transform="translate(-10.000000, 0.000000)">
+            <polygon id="Polygon" fill="url(#linearGradient-1)" points="80 0 149.282032 40 149.282032 120 80 160 10.7179677 120 10.7179677 40"></polygon>
+            <polygon id="Polygon" fill="#000000" points="79.693575 18 133.38715 49 133.38715 111 79.693575 142 26 111 26 49"></polygon>
+        </g>
+    </g>
+</svg>

--- a/css/home.css
+++ b/css/home.css
@@ -236,7 +236,7 @@ h2 {
 }
 
 .article {
-    margin: 1em auto;
+    margin: 3em auto;
 }
 
 .article:nth-child(odd) > .article-img {

--- a/css/home.css
+++ b/css/home.css
@@ -942,13 +942,24 @@ a.gradient-text.gradient-underline.border-jump {
 .exec-member {
     /*line-height: 0.5em;*/
     text-align: center;
+    /*flex: 1 0 0;*/
+    flex: 1;
+    flex-grow: 1;
+    flex-basis: 0;
+    padding: 0 1em;
+}
+
+.exec-row {
+    display: flex;
+    flex: 1;
+    flex-wrap: wrap;
 }
 
 .exec-member-img {
     -webkit-clip-path: polygon(50% 0%, 90% 25%, 90% 75%, 50% 100%, 10% 75%, 10% 25%);
     clip-path: polygon(50% 0%, 90% 25%, 90% 75%, 50% 100%, 10% 75%, 10% 25%);
 
-    width: 100%;
+    /*width: 100%;*/
     background-size: cover;
 }
 
@@ -1255,8 +1266,12 @@ div.post * {
         text-align: left;
     }
 
-    .exec-member {
+    /*.exec-member {
         width: 25%;
+    }*/
+
+    .exec-row * {
+        font-size: 0.9em;
     }
 
     .exec-member p {

--- a/css/home.css
+++ b/css/home.css
@@ -1131,7 +1131,7 @@ a.gradient-text.gradient-underline.border-jump {
 }
 
 #events p {
-    color: #676767;
+    font-size: 1.05em;
 }
 
 .team-glyphs {
@@ -1273,4 +1273,26 @@ div.post * {
         bottom: 5%;
     }
 
+}
+
+@media (min-width: 720px) {
+    /*event page changes for larger screens*/
+    #events h2 {
+        font-size: 1.8em;
+    }
+
+    #events p {
+        font-size: 1.15em;
+    }
+
+    #events {
+        position: relative;
+    }
+
+    #events .chevron-container {
+        position: absolute;
+        left: 0;
+        bottom: 0;
+        width: 100%;
+    }
 }

--- a/css/home.css
+++ b/css/home.css
@@ -1087,6 +1087,20 @@ a.gradient-text.gradient-underline.border-jump {
     color: #676767;
 }
 
+#events .row {
+    width: 100%;
+}
+
+.col-7.blurbs {
+    display: block;
+    max-width: 100%;
+}
+
+#events .col-7.blurbs * {
+    width: 90%;
+    padding-left: 1rem;
+}
+
 #year-selector {
     position: fixed;
     right: 5%;

--- a/css/home.css
+++ b/css/home.css
@@ -385,7 +385,7 @@ footer a {
 
 .about-slogan {
     color: white;
-    padding: 0 1.5em;
+    padding: 0 3em;
     margin: 0;
     font-weight: 400;
 }
@@ -945,10 +945,6 @@ a.gradient-text.gradient-underline.border-jump {
     text-align: center;
 }
 
-.exec-member p {
-    overflow-wrap: break-word;
-}
-
 .exec-member-img {
     -webkit-clip-path: polygon(50% 0%, 90% 25%, 90% 75%, 50% 100%, 10% 75%, 10% 25%);
     clip-path: polygon(50% 0%, 90% 25%, 90% 75%, 50% 100%, 10% 75%, 10% 25%);
@@ -1248,6 +1244,10 @@ div.post * {
 
     .exec-member {
         width: 25%;
+    }
+
+    .exec-member p {
+        overflow-wrap: break-word;
     }
 
     #splash-nav > h1.big {

--- a/css/home.css
+++ b/css/home.css
@@ -941,6 +941,9 @@ a.gradient-text.gradient-underline.border-jump {
     text-align: center;
 }
 
+.exec-member p {
+    overflow-wrap: break-word;
+}
 
 .exec-member-img {
     -webkit-clip-path: polygon(50% 0%, 90% 25%, 90% 75%, 50% 100%, 10% 75%, 10% 25%);

--- a/css/home.css
+++ b/css/home.css
@@ -1281,6 +1281,15 @@ div.post * {
     #splash-nav > h1.big {
         text-align: center;
         float: none;
+        font-size: 1.5em;
+    }
+
+    #splash-nav > h1.big > a {
+        position: relative;
+    }
+
+    #splash-nav > h1.big > a::after {
+        height: 2px;
     }
 
     #splash-nav > ul {

--- a/css/home.css
+++ b/css/home.css
@@ -800,10 +800,6 @@ a.gradient-text.gradient-underline.border-jump {
         font-size: 2em;
     }
 
-    section {
-        min-height: 125%;
-    }
-
     .we-are h1, .info-chunk h1 {
         font-size: 150%;
     }
@@ -1271,6 +1267,10 @@ div.post * {
 
     .article-links > a {
         display: inline;
+    }
+
+    #slogan {
+        bottom: 5%;
     }
 
 }

--- a/css/home.css
+++ b/css/home.css
@@ -785,7 +785,6 @@ a.gradient-text.gradient-underline.border-jump {
         width: 100%;
         text-align: center;
     }
-
 }
 
 @media (max-width:480px) {
@@ -793,6 +792,10 @@ a.gradient-text.gradient-underline.border-jump {
     body {
         /* make font readable */
         font-size: 125%;
+    }
+
+    #splash-nav > ul {
+        font-size: 0.75em;
     }
 
     .featured-post .title {

--- a/css/home.css
+++ b/css/home.css
@@ -465,6 +465,10 @@ footer a {
     opacity: 0;
 }
 
+.info-chunk p {
+    font-size: 1.17em;
+}
+
 .info-container {
     position: relative;
     width: 60%;

--- a/css/home.css
+++ b/css/home.css
@@ -714,6 +714,10 @@ a.gradient-text.gradient-underline.border-jump {
     color: white;
 }
 
+#contact h2 {
+    font-family: 'Barlow', sans-serif;
+}
+
 .contact-text, .contact-email {
     min-height: 28em !important; /* kind of just guessed this height ?? */
     display: flex;

--- a/js/about.js
+++ b/js/about.js
@@ -44,6 +44,9 @@ var widthOffsetRatio = 0.4;
 var distanceFactor = 1.05;
 
 updateHexagonContainerHeight();
+resizeInfoChunks();
+
+window.onresize = resizeInfoChunks;
 
 function updateHexagonContainerHeight() {
     height = footer.offsetTop - hexagonContainer.offsetTop;
@@ -331,4 +334,16 @@ function shuffle(a) {
         a[i] = a[j];
         a[j] = x;
     }
+}
+
+function resizeInfoChunks() {
+    var infoChunks = [].slice.call(document.getElementsByClassName('info-chunk'));
+
+    var maxHeight = 0;
+
+    infoChunks.forEach(function(e){
+        maxHeight = Math.max(maxHeight, e.offsetHeight);
+    });
+
+    infoChunks[0].parentElement.style.minHeight = maxHeight + "px";
 }


### PR DESCRIPTION
First round of small adjustments:
- fixed broken links under pictures on home page
- fixed broken 'attend' link on home page
- fixed capitalization on code page
- made the 'catch us on social media' on contact page the same font as the rest of the text
- added timeline-glyph.svg which was missing earlier
- made the about page team description the same font size as the paragraphs on top 
- added more spacing between the blurbs on the front page
- add word breaking to exec member descriptions on event page to avoid overlap on smaller screens 