### PR TITLE
Fix phantom hexagon: Part II

### DIFF
--- a/_pages/home.html
+++ b/_pages/home.html
@@ -45,6 +45,7 @@ footer-js:
 
         </section>
 
+        <img id="logo" src="assets/hackgt.svg" alt="HackGT Logo" />
         <svg id="canvas" width="100%" height="100%"></svg>
 
        <section id="about" class="dark container">

--- a/assets/hackgt.svg
+++ b/assets/hackgt.svg
@@ -1,17 +1,24 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 500 475">
     <!-- Generator: Sketch 47.1 (45422) - http://www.bohemiancoding.com/sketch -->
-    <title>hackgt</title>
-    <desc>Created with Sketch.</desc>
+    <title>HackGT</title>
     <defs>
-        <linearGradient x1="0%" y1="0%" x2="138.635783%" y2="144.321429%" id="linearGradient-1">
-            <stop stop-color="#8B54A2" offset="0%"></stop>
-            <stop stop-color="#4AC8EF" offset="100%"></stop>
-        </linearGradient>
+        <filter id="logo-shadow" filterUnits="userSpaceOnUse">
+            <feGaussianBlur in="SourceAlpha" stdDeviation ="16" />
+            <feOffset dx="0" dy="0" result="offsetblur" />
+            <feFlood flood-color="#e5fbff" />
+            <feComposite in2="offsetblur" operator="in" />
+            <feComponentTransfer>
+                <feFuncA type="linear" slope="0.9" />
+            </feComponentTransfer>
+            <feMerge>
+                <feMergeNode/>
+                <feMergeNode in="SourceGraphic" />
+            </feMerge>
+        </filter>
     </defs>
-    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="hackgt" transform="translate(17.000000, 20.000000)" fill="url(#linearGradient-1)">
-            <path d="M111,275.049583 L111,206.185045 L187.530744,162 L187.530744,54 L94,0 L0.469256391,54 L0.469256391,162 L77,206.185045 L77,226.270925 L-17,172 L-17,44 L93.8512517,-20 L204.702503,44 L204.702503,151.900834 L205,151.729075 L205,171.814955 L204.702503,171.986714 L204.702503,172 L128.469256,216.013286 L128.469256,324 L222,378 L315.530744,324 L315.530744,216 L239,171.814955 L239,151.900834 L332.702503,206 L332.702503,334 L221.851252,398 L111,334 L111,275.049583 Z M222,200 L286.951905,237.5 L286.951905,312.5 L222,350 L157.048095,312.5 L157.048095,237.5 L222,200 Z M94,31 L158.951905,68.5 L158.951905,143.5 L94,181 L29.0480947,143.5 L29.0480947,68.5 L94,31 Z" id="Combined-Shape"></path>
-        </g>
+    
+    <g id="hackgt" transform="translate(90.000000, 50.000000)" fill="#e5fbff" filter="url('#logo-shadow')">
+        <path d="M111,275.049583 L111,206.185045 L187.530744,162 L187.530744,54 L94,0 L0.469256391,54 L0.469256391,162 L77,206.185045 L77,226.270925 L-17,172 L-17,44 L93.8512517,-20 L204.702503,44 L204.702503,151.900834 L205,151.729075 L205,171.814955 L204.702503,171.986714 L204.702503,172 L128.469256,216.013286 L128.469256,324 L222,378 L315.530744,324 L315.530744,216 L239,171.814955 L239,151.900834 L332.702503,206 L332.702503,334 L221.851252,398 L111,334 L111,275.049583 Z M222,200 L286.951905,237.5 L286.951905,312.5 L222,350 L157.048095,312.5 L157.048095,237.5 L222,200 Z M94,31 L158.951905,68.5 L158.951905,143.5 L94,181 L29.0480947,143.5 L29.0480947,68.5 L94,31 Z" id="Combined-Shape"></path>
     </g>
 </svg>

--- a/css/home.css
+++ b/css/home.css
@@ -34,6 +34,11 @@ section {
     background: none;
 }
 
+#logo {
+    position: absolute;
+    height: 40vh;
+    top: calc(45% - (40vh / 2));
+}
 #canvas {
     width: 100%;
     height: 100vh;

--- a/js/home.js
+++ b/js/home.js
@@ -22,8 +22,6 @@ var radiusMax = Math.min(width / radiusMaxRatio, height / radiusMaxRatio);
 
 var center = {x: width / 2, y: height / 2};
 
-var logoCenterOffsetRatio = 0.85;
-
 var numHexagons = 15;
 var hexagonMinSize = 10;
 var hexagonMaxSize = 20;
@@ -43,12 +41,7 @@ var intervalSpeed = 1000/fps;
 var baseDeltaT = 0.005;
 var deltaDeltaT = -0.005;
 
-var logo = null;
-
-var logoColor = "#e5fbff";
-
 var shadow = s.filter(Snap.filter.shadow(0,0,8,"#dddddd",0.9));
-var logoShadow = s.filter(Snap.filter.shadow(0,0,16,logoColor,0.9));
 
 // the shadows actually skullfuck your battery life, so probs not gonna use them bc my fan get so loud
 var useFilters = false;
@@ -145,7 +138,6 @@ function emptyCanvas() {
     hexagons = [];
 }
 
-var logoDownloadTriggered = false;
 function init() {
     
     if (s) {
@@ -186,45 +178,10 @@ function init() {
         hexagons.push(hexagon);
     }
 
-    if (!logo) {
-        if (!logoDownloadTriggered) {
-            // Don't trigger another download if we're still waiting on the network
-            logoDownloadTriggered = true;
-            // note, when adding an SVG, make sure the height/width/viewbox attributes from the top svg node are removed from the actual .svg file
-            Snap.load('./assets/hackgt.svg', function(loadedFragment) {
-                s.append(loadedFragment);
-                logo = s.select('#hackgt');
-                // useFilters && logo.attr({filter: lightShadow});
-                logo.attr({filter: logoShadow});
-                logo.attr({fill: logoColor});
-                centerLogo();
-            });
-        }
-    } else {
-        centerLogo();
-    }
-
     if (animationInterval) {
         window.cancelAnimationFrame(animationInterval);
     }
     animationInterval = window.requestAnimationFrame(animateValence);
-}
-
-function centerLogo() {
-    // logo.transform('s1,1T0,0');
-    logo.transform('');
-
-    var bb = logo.getBBox();
-    var dx = center.x - bb.cx;
-    var dy = (center.y - bb.cy) * logoCenterOffsetRatio;
-
-    var scaleAmount = (Math.min(width, height) / 3) / Math.max(bb.w, bb.h);
-
-    logo.transform('s' + scaleAmount + ',' + scaleAmount + 'T'+dx+','+dy);
-
-    // note, this doesn't add another logo, it just pushed the logo to the 'top', so the little
-    // hexagons render behind it
-    s.append(logo);
 }
 
 function createNormalPolygon(radius, degree) {

--- a/js/home.js
+++ b/js/home.js
@@ -108,6 +108,7 @@ function animateValence() {
     }
 
     timer += (baseDeltaT + easedOutScrollAmount * deltaDeltaT);
+    animationInterval = window.requestAnimationFrame(animateValence);
 }
 
 function updateScrollAmount() {
@@ -203,8 +204,10 @@ function init() {
         centerLogo();
     }
 
-    clearInterval(animationInterval);
-    animationInterval = setInterval(animateValence, intervalSpeed);
+    if (animationInterval) {
+        window.cancelAnimationFrame(animationInterval);
+    }
+    animationInterval = window.requestAnimationFrame(animateValence);
 }
 
 function centerLogo() {


### PR DESCRIPTION
Different JS contexts prevented #71 from working as intended. This PR fixes the issue by removing the SVG HackGT logo from the main canvas (where it had to be inserted via JS) to static HTML and CSS. This improves performance and makes the whole thing less hacky.

Also changed `setTimeout()` usage to `requestAnimationFrame` for battery life, smoothness, and performance improvements.

Fixes #62 